### PR TITLE
Handle AI/AM basis of strength

### DIFF
--- a/ndc_unii.py
+++ b/ndc_unii.py
@@ -85,7 +85,7 @@ def load_scd_attrs(rxnsat_path):
 
             # ATV contains "{SCDC_RxCUI} INGREDIENT_RxCUI"; parse both
             atv = row[10].strip()
-            m = re.search(r"\{(\d+)\}\s*(\d+)", atv)
+            m = re.search(r"\{(\d+)\}\s*(\d+|AI|AM)", atv)
             if not m:
                 continue
             scdc, target = m.group(1), m.group(2)
@@ -97,7 +97,7 @@ def load_scd_attrs(rxnsat_path):
             elif atn == "RXN_AI":
                 ai[scd][scdc] = target
             else:  # RXN_BOSS_FROM
-                boss[scd][scdc] = target
+                boss[scd][scdc] = target  # target may be RxCUI or 'AI'/'AM'
     return am, ai, boss
 
 # ---------- RXNREL: hops (bidirectional where needed) ----------
@@ -188,9 +188,15 @@ def main():
             ai_by_scdc   = ai_map.get(scd, {})
             boss_by_scdc = boss_map.get(scd, {})
             for scdc in scd_to_scdc.get(scd, ()):
-                ai_target   = ai_by_scdc.get(scdc)
-                am_target   = am_by_scdc.get(scdc)
-                boss_target = boss_by_scdc.get(scdc)
+                ai_target  = ai_by_scdc.get(scdc)
+                am_target  = am_by_scdc.get(scdc)
+                boss_key   = boss_by_scdc.get(scdc)
+                if boss_key == "AI":
+                    boss_target = ai_target
+                elif boss_key == "AM":
+                    boss_target = am_target
+                else:
+                    boss_target = boss_key
                 # PINs
                 for pin in scdc_to_pin.get(scdc, ()):
                     key = (scdc, pin)


### PR DESCRIPTION
## Summary
- parse `RXN_BOSS_FROM` entries that signal basis-of-strength via active ingredient or active moiety
- resolve `AI`/`AM` markers to the corresponding ingredient when marking basis of strength

## Testing
- `python -m py_compile ndc_unii.py`
- `python ndc_unii.py` *(fails: Missing RXNSAT.RRF in /workspace/ndc-unii)*

------
https://chatgpt.com/codex/tasks/task_e_68a339399a748327ad6d21d0fcae6bd9