### PR TITLE
Sort ndc_unii output and test data deterministically

### DIFF
--- a/ndc_unii.py
+++ b/ndc_unii.py
@@ -233,6 +233,8 @@ def main():
             # Only keep rows that have at least one ingredient
             if not ingredients:
                 continue
+            # Sort ingredients deterministically
+            ingredients.sort(key=lambda ing: (ing["scdc"], ing["tty"], ing["rxcui"]))
 
             out.append({
                 "ndc": ndc,
@@ -242,6 +244,8 @@ def main():
                 "ingredients": ingredients
             })
 
+    # Ensure deterministic order of records
+    out.sort(key=lambda rec: (rec["ndc"], rec["tty"], rec["rxcui"]))
     with open(OUTPUT, "w", encoding="utf-8") as g:
         json.dump(out, g, indent=2)
     print(f"Wrote {len(out)} rows to {OUTPUT}")

--- a/test_ndc_unii.py
+++ b/test_ndc_unii.py
@@ -73,6 +73,8 @@ def build_expected():
                     })
             if not ingredients:
                 continue
+            # Sort ingredients deterministically to mirror script output
+            ingredients.sort(key=lambda ing: (ing["scdc"], ing["tty"], ing["rxcui"]))
             out.append({
                 "ndc": ndc,
                 "tty": dtty,
@@ -80,6 +82,8 @@ def build_expected():
                 "str": name_map.get(direct, ""),
                 "ingredients": ingredients,
             })
+    # Sort final records as script does
+    out.sort(key=lambda rec: (rec["ndc"], rec["tty"], rec["rxcui"]))
     return out
 
 


### PR DESCRIPTION
## Summary
- Sort ingredients within each record by `(scdc, tty, rxcui)`
- Sort top-level records by `(ndc, tty, rxcui)`
- Apply matching sorting in tests for deterministic comparison

## Testing
- `pytest -q` *(fails: Missing RXNSAT.RRF in /workspace/ndc-unii)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a8f57c208327965ca74ef46427d3