### PR TITLE
Improve test diff diagnostics

### DIFF
--- a/test_ndc_unii.py
+++ b/test_ndc_unii.py
@@ -2,6 +2,8 @@ import json
 import subprocess
 import sys
 
+import pytest
+
 import ndc_unii
 
 
@@ -88,4 +90,22 @@ def test_json_matches_rrf():
     with open("ndc_unii_rxnorm.json", encoding="utf-8") as f:
         data = json.load(f)
     expected = build_expected()
-    assert data == expected
+    for datum, exp in zip(data, expected):
+        if datum != exp:
+            pair = {"data": datum, "expected": exp}
+            pytest.fail(
+                "Record mismatch for NDC {d_ndc}/RxCUI {d_rxcui} vs NDC {e_ndc}/RxCUI {e_rxcui}\n"
+                "data ingredients:\n{d_ing}\nexpected ingredients:\n{e_ing}\nfull diff:\n{diff}".format(
+                    d_ndc=datum.get("ndc"),
+                    d_rxcui=datum.get("rxcui"),
+                    e_ndc=exp.get("ndc"),
+                    e_rxcui=exp.get("rxcui"),
+                    d_ing=json.dumps(datum.get("ingredients"), indent=2),
+                    e_ing=json.dumps(exp.get("ingredients"), indent=2),
+                    diff=json.dumps(pair, indent=2),
+                )
+            )
+    if len(data) != len(expected):
+        pytest.fail(
+            f"Length mismatch: {len(data)} records vs {len(expected)} expected"
+        )


### PR DESCRIPTION
## Summary
- Replace bare equality assertion with detailed record comparison.
- Report first mismatch with NDC/RxCUI, ingredient lists, and full JSON diff.

## Testing
- `pytest -q` *(fails: Missing RXNSAT.RRF in /workspace/ndc-unii)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a8f6cd248327893b4f2a9ca45c5c