### PR TITLE
Stop escaping quotes in HTML test report

### DIFF
--- a/test_ndc_unii.py
+++ b/test_ndc_unii.py
@@ -144,7 +144,8 @@ def test_json_matches_rrf():
         steps.append(f"Loaded {len(data)} records from ndc_unii_rxnorm.json")
         data_counts = summarize_counts(data)
         steps.append(
-            "Output dataset counts: " + html.escape(json.dumps(data_counts, sort_keys=True))
+            "Output dataset counts: "
+            + html.escape(json.dumps(data_counts, sort_keys=True), quote=False)
         )
 
         steps.append("Building expected dataset from RxNorm RRF files")
@@ -152,7 +153,8 @@ def test_json_matches_rrf():
         steps.append(f"Built expected dataset with {len(expected)} records")
         expected_counts = summarize_counts(expected)
         steps.append(
-            "Expected dataset counts: " + html.escape(json.dumps(expected_counts, sort_keys=True))
+            "Expected dataset counts: "
+            + html.escape(json.dumps(expected_counts, sort_keys=True), quote=False)
         )
 
         steps.append("Comparing script output to expected data")
@@ -173,7 +175,9 @@ def test_json_matches_rrf():
             if mismatch_counts:
                 steps.append(
                     "Mismatch counts by field: "
-                    + html.escape(json.dumps(dict(mismatch_counts), sort_keys=True))
+                    + html.escape(
+                        json.dumps(dict(mismatch_counts), sort_keys=True), quote=False
+                    )
                 )
             pair = mismatches[0]
             datum, exp = pair["data"], pair["expected"]
@@ -211,5 +215,5 @@ def test_json_matches_rrf():
                 "</title></head><body><h1>test_json_matches_rrf Report</h1><ul>"
             )
             for step in steps:
-                rep.write(f"<li>{html.escape(str(step))}</li>")
+                rep.write(f"<li>{html.escape(str(step), quote=False)}</li>")
             rep.write("</ul></body></html>")


### PR DESCRIPTION
## Summary
- prevent `html.escape` from turning quotes into `&quot;` in the HTML report generated by `test_json_matches_rrf`

## Testing
- `pytest -q` *(fails: Missing RXNSAT.RRF in /workspace/ndc-unii)*

------
https://chatgpt.com/codex/tasks/task_e_68af5be89bd88327a3d892afa33a045f